### PR TITLE
fix: faceted survey↔content tag matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
     "redis (>=5.0.0,<7.0.0)",
     "requests (>=2.32.0,<3.0.0)",
     "pyarrow (>=17.0.0,<22.0.0)",
+    # shared tag taxonomy / match normalization (single source of truth).
+    # local dev: `pip install -e ../memorise-taxonomy`
+    "memorise-taxonomy",
 ]
 
 [tool.poetry]

--- a/src/ai_engine/recsys/api.py
+++ b/src/ai_engine/recsys/api.py
@@ -151,6 +151,8 @@ def _served_record(request_id: str, user_id: str, items: list, out: dict, filter
         "ranking": (out.get("diagnostics") or {}).get("ranking"),
         "distractor_id": distractor,
         "items": [{"id": it["id"], "rank": it["rank"], "role": it["role"],
+                   "relevance_score": it.get("relevance_score"),
+                   "breakdown": it.get("breakdown", {}),
                    "features": it.get("features", [])} for it in items],
     }
 
@@ -377,6 +379,71 @@ def make_router(components: Components) -> APIRouter:
             out["cluster"] = (assign_fuzzy(sig, model) if model.get("method") == "fcm"
                               else assign(sig, model))
         return {"result": out}
+
+    @usermodel_routes.get("/usermodel/extras")
+    def usermodel_extras(user_id: str = Query(..., examples=["u1"])) -> dict:
+        """Holistic visitor profile extras that complement /usermodel/explain:
+        demographics, the raw survey answers (presurvey + personalization), and the
+        dynamic user model (tag affinities/aversions, engagement behaviour, and the
+        content the visitor engaged with positively together with that content's
+        tags — i.e. *why* we think the visitor likes certain things)."""
+        from .survey import extract_demographics, split_survey_answers
+
+        sig = c.model_store.get_signals(user_id)
+        if sig is None:
+            return {"result": None}
+
+        # Raw survey answers, merged across all of this visitor's events (latest wins).
+        answers: dict = {}
+        for ev in (c.event_buffer.fetch_events(user_id) or []):
+            for k, val in (getattr(ev, "survey_answers", None) or {}).items():
+                if val is not None and val != "":
+                    answers[k] = val
+        grouped = split_survey_answers(answers)
+        surveys = {
+            "demographic": grouped["demographic"],
+            "personalization": grouped["personalization"],
+            "other": grouped["other"],
+            "completed_demographic": bool(grouped["demographic"]),
+            "completed_personalization": bool(grouped["personalization"]),
+            "answer_count": len(answers),
+        }
+
+        demographics = dict(sig.demographics or {}) or extract_demographics(answers)
+
+        # Dynamic model: content the visitor liked, with that content's tags.
+        positives = sig.positives or {}
+        liked_ids = sorted(positives, key=lambda k: positives[k], reverse=True)[:15]
+        contents = c.content_store.get(liked_ids) if liked_ids else {}
+        liked_content = []
+        for cid in liked_ids:
+            ct = contents.get(cid)
+            liked_content.append({
+                "id": cid,
+                "title": getattr(ct, "title", None) if ct else None,
+                "weight": round(float(positives.get(cid, 0.0)), 3),
+                "tags": [t.key for t in getattr(ct, "tags", [])] if ct else [],
+            })
+
+        def _top(d, n=12):
+            d = d or {}
+            ranked = sorted(d.items(), key=lambda kv: abs(kv[1]), reverse=True)[:n]
+            return [{"key": k, "weight": round(float(v), 3)} for k, v in ranked]
+
+        model = {
+            "tag_affinity": _top(sig.tag_affinity),
+            "tag_aversion": _top(sig.tag_aversion),
+            "behavior": dict(sig.behavior or {}),
+            "liked_content": liked_content,
+            "counts": {
+                "positives": len(sig.positives or {}),
+                "negatives": len(sig.negatives or {}),
+                "viewed": len(sig.viewed or []),
+            },
+            "is_cold": bool(getattr(sig, "is_cold", False) or not (sig.viewed)),
+        }
+
+        return {"result": {"demographics": demographics, "surveys": surveys, "model": model}}
 
     @usermodel_routes.get("/usermodel/history")
     def usermodel_history(
@@ -658,6 +725,108 @@ def make_router(components: Components) -> APIRouter:
                     items = []
             out.append({**r, "items": items})
         return {"result": out}
+
+    @ops.get("/served/explain")
+    def served_explain(request_id: str = Query(..., description="served impression request_id")) -> dict:
+        """Explain a past recommendation: the served items, the visitor's current tag
+        model, and — per item — the overlap between the visitor's tag affinities and the
+        content's tags, plus the stored per-scorer breakdown (the other reasons it was
+        ranked). Impressions logged before the breakdown was persisted ('legacy') still
+        return live-computed tag overlap; has_breakdown flags that case for the UI."""
+        import glob
+        import json
+        base = _log_base(c)
+        if not base:
+            return {"result": None, "detail": "EVENT_LOG_DIR not set"}
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:
+            return {"result": None, "detail": "pyarrow not installed"}
+        rec = None
+        for f in glob.glob(os.path.join(base, "served", "**", "*.parquet"), recursive=True):
+            try:
+                for r in pq.read_table(f).to_pylist():
+                    if r.get("request_id") == request_id:
+                        rec = r
+                        break
+            except Exception:
+                continue
+            if rec is not None:
+                break
+        if rec is None:
+            return {"result": None, "detail": "request_id not found"}
+
+        items = rec.get("items")
+        if isinstance(items, str):
+            try:
+                items = json.loads(items)
+            except Exception:
+                items = []
+        items = items or []
+
+        user_id = rec.get("user_id")
+        sig = c.model_store.get_signals(user_id) if user_id else None
+        affinity = (getattr(sig, "tag_affinity", None) or {}) if sig else {}
+        # The tag scorer matches user affinity to content tags on NORMALIZED keys
+        # (casing/whitespace/synonyms), so the overlap shown here must normalize the
+        # same way — otherwise "theme_what:Family" (raw tag) would miss
+        # "theme_what:family" (affinity). Single source of truth: taxonomy.normalize_key.
+        from .taxonomy import normalize_key
+        aff_norm = {}
+        for k, val in affinity.items():
+            aff_norm[normalize_key(k)] = float(val)
+
+        ids = [it.get("id") for it in items if it.get("id")]
+        contents = c.content_store.get(ids) if ids else {}
+        has_breakdown = any(it.get("breakdown") for it in items)
+
+        out_items = []
+        for it in items:
+            cid = it.get("id")
+            ct = contents.get(cid)
+            content_tags = [t.key for t in getattr(ct, "tags", [])] if ct else []
+            overlap = [
+                {"key": k, "user_weight": round(aff_norm[normalize_key(k)], 3)}
+                for k in content_tags if normalize_key(k) in aff_norm
+            ]
+            overlap.sort(key=lambda o: o["user_weight"], reverse=True)
+            out_items.append({
+                "id": cid,
+                "title": getattr(ct, "title", None) if ct else None,
+                "rank": it.get("rank"),
+                "role": it.get("role"),
+                "relevance_score": it.get("relevance_score"),
+                "breakdown": it.get("breakdown") or {},
+                "content_tags": content_tags,
+                "tag_overlap": overlap,
+            })
+
+        # Persona-level view of the same user model (so the UI can speak the same language).
+        user_model = None
+        if sig is not None:
+            from .explain.persona import explain_user
+            contents_seen = c.content_store.get(sig.viewed or [])
+            user_model = explain_user(sig, contents_seen).model_dump()
+
+        user_tag_affinity = [
+            {"key": k, "weight": round(float(v), 3)}
+            for k, v in sorted(affinity.items(), key=lambda kv: kv[1], reverse=True)[:15]
+        ]
+
+        return {"result": {
+            "request_id": request_id,
+            "user_id": user_id,
+            "ts": rec.get("ts"),
+            "strategy": rec.get("strategy"),
+            "filter": rec.get("filter"),
+            "cold_start": rec.get("cold_start"),
+            "ranking": rec.get("ranking"),
+            "distractor_id": rec.get("distractor_id"),
+            "has_breakdown": bool(has_breakdown),
+            "user_model": user_model,
+            "user_tag_affinity": user_tag_affinity,
+            "items": out_items,
+        }}
 
     @write.post("/recommend/preview")
     def recommend_preview(

--- a/src/ai_engine/recsys/ranking/scorers.py
+++ b/src/ai_engine/recsys/ranking/scorers.py
@@ -7,6 +7,7 @@ import math
 from typing import Optional
 
 from ..contracts.models import Content, UserSignals, Vector
+from ..taxonomy import normalize_key
 
 
 def cosine(a: Optional[Vector], b: Optional[Vector]) -> float:
@@ -80,14 +81,15 @@ def score_tag(signals: UserSignals, content: Optional[Content]) -> float:
     """
     if content is None or not signals.tag_affinity:
         return 0.0
-    # match case-insensitively: taxonomy casing (e.g. "female", "Photograph") must
-    # line up with constructed keys (e.g. demographic "...:Female").
-    cand_weights = {t.key.lower(): t.weight for t in content.tags}
+    # match on canonical form: survey-derived keys and content keys must agree
+    # despite casing/whitespace/accents/separators/typos. normalize_key is the
+    # single source of truth, applied symmetrically to both sides.
+    cand_weights = {normalize_key(t.key): t.weight for t in content.tags}
     total = sum(signals.tag_affinity.values())
     if total <= 0:
         return 0.0
     matched = sum(
-        aff * cand_weights.get(key.lower(), 0.0)
+        aff * cand_weights.get(normalize_key(key), 0.0)
         for key, aff in signals.tag_affinity.items()
     )
     return max(0.0, min(matched / total, 1.0))
@@ -99,12 +101,12 @@ def score_aversion(signals: UserSignals, content: Optional[Content]) -> float:
     sharing themes with abandoned content is pushed down."""
     if content is None or not signals.tag_aversion:
         return 0.0
-    cand_weights = {t.key.lower(): t.weight for t in content.tags}
+    cand_weights = {normalize_key(t.key): t.weight for t in content.tags}
     total = sum(signals.tag_aversion.values())
     if total <= 0:
         return 0.0
     matched = sum(
-        av * cand_weights.get(key.lower(), 0.0)
+        av * cand_weights.get(normalize_key(key), 0.0)
         for key, av in signals.tag_aversion.items()
     )
     return max(0.0, min(matched / total, 1.0))

--- a/src/ai_engine/recsys/recommender.py
+++ b/src/ai_engine/recsys/recommender.py
@@ -15,6 +15,7 @@ from .contracts.models import (
     UserSignals,
 )
 from .contracts.ports import ContentStore, UserModelStore
+from .taxonomy import normalize_key
 from .ranking.scorers import (
     score_semantic, score_affinity, score_tag, score_recency, score_aversion, score_geo,
 )
@@ -93,7 +94,8 @@ class Recommender:
                 for c in self.content_store.search_vector(signals.taste_vector, limit=cfg.pool_per_generator):
                     pool.setdefault(c.content_id, c)
             top_tag_keys = [
-                k for k, _ in sorted(signals.tag_affinity.items(), key=lambda kv: kv[1], reverse=True)
+                normalize_key(k)
+                for k, _ in sorted(signals.tag_affinity.items(), key=lambda kv: kv[1], reverse=True)
             ][:20]
             if top_tag_keys:
                 for c in self.content_store.search_tags(top_tag_keys, limit=cfg.pool_per_generator):

--- a/src/ai_engine/recsys/static/dashboard.html
+++ b/src/ai_engine/recsys/static/dashboard.html
@@ -446,18 +446,20 @@ const SCOPE={};GROUPS.forEach(g=>Object.keys(g.tabs).forEach(t=>SCOPE[t]=g.label
 const BY_SLUG={};Object.keys(ALL).forEach(n=>BY_SLUG[slug(n)]=n);
 let current="Cohort";
 let userCtx=null;            // {id, sub} when drilled into a single visitor (from the Cohort table)
+let recCtx=null;             // request_id when drilled into a single recommendation (from the Traffic table)
 let cfgTab=null;             // active Config category subtab
 let cfgEdit=false;           // Config is read-only until Edit is clicked
 const USER_SUBS=[["profile","Profile",renderUser],["history","History",renderHistory],["recommend","Recommend",renderRequest]];
 
-function setTab(n){if(!ALL[n])return;userCtx=null;cfgEdit=false;current=n;const s=slug(n);if(location.hash!=="#/"+s)location.hash="#/"+s;else paint();}
-function openUser(id,sub){id=String(id).trim();if(!id)return;sub=sub||"profile";cfgEdit=false;
+function setTab(n){if(!ALL[n])return;userCtx=null;recCtx=null;cfgEdit=false;current=n;const s=slug(n);if(location.hash!=="#/"+s)location.hash="#/"+s;else paint();}
+function openUser(id,sub){id=String(id).trim();if(!id)return;sub=sub||"profile";cfgEdit=false;recCtx=null;
   $("#uid").value=id;localStorage.setItem("ins_uid",id);
   const h=`#/user/${encodeURIComponent(id)}/${sub}`;if(location.hash!==h)location.hash=h;else paint();}
 function paint(){
-  const navActive=userCtx?"Cohort":current;
+  const navActive=recCtx?"Traffic":userCtx?"Cohort":current;
   for(const b of document.querySelectorAll(".navitem"))b.classList.toggle("on",b.dataset.t===navActive);
   const v=$("#view");v.innerHTML="";
+  if(recCtx){renderRecDetail(v);return;}
   if(userCtx){renderUserDetail(v);return;}
   v.append(el("div",{class:"pagehead"},
     el("div",{},el("div",{class:"eyebrow"},SCOPE[current]),el("h1",{},current)),
@@ -478,6 +480,76 @@ function renderUserDetail(v){
   const host=el("div");v.append(host);
   fn(host).catch(e=>failCard(host,e));
 }
+
+function openRec(rid){
+  rid=String(rid||"").trim();if(!rid)return;userCtx=null;cfgEdit=false;
+  const h=`#/rec/${encodeURIComponent(rid)}`;
+  if(location.hash!==h)location.hash=h;else paint();
+}
+async function renderRecDetail(v){
+  v.append(el("div",{class:"pagehead"},
+    el("div",{},el("div",{class:"eyebrow"},"Traffic"),el("h1",{},"Recommendation")),
+    el("button",{class:"iconbtn",title:"back to traffic",onclick:()=>{location.hash="#/traffic";}},"←")));
+  const host=el("div");v.append(host);
+  let d;
+  try{d=await api(`/api/served/explain?request_id=${encodeURIComponent(recCtx)}`);}catch(e){failCard(host,e);return;}
+  if(!d){host.append(el("div",{class:"empty"},"Recommendation ",el("b",{},recCtx)," not found in the served log."));return;}
+  // ----- meta: why served -----
+  const meta=el("div",{class:"card"},cardhead("Why this was served"));
+  meta.append(el("div",{class:"row",style:"gap:7px;flex-wrap:wrap;margin-bottom:6px"},
+    el("span",{class:"pill "+(d.strategy||"warm")},"strategy: "+(d.strategy||"?")),
+    d.ranking?el("span",{class:"pill neutral"},"ranking: "+d.ranking):"",
+    d.cold_start?el("span",{class:"pill cold"},"cold start"):"",
+    d.filter?el("span",{class:"pill neutral"},"filter: "+d.filter):""));
+  meta.append(el("div",{class:"small mut"},
+    "visitor ",el("button",{class:"userchip",title:"open visitor",onclick:()=>openUser(d.user_id,"profile")},d.user_id||"?"),
+    "   ·   "+((d.ts||"").replace("T"," ").slice(0,19))));
+  if(!d.has_breakdown)meta.append(el("div",{class:"small mut",style:"margin-top:8px;font-style:italic"},
+    "Legacy impression: the per-scorer breakdown was not recorded at serve time. Tag overlap below is computed against the visitor's current model."));
+  host.append(meta);
+  // ----- the user model -----
+  if(d.user_model){
+    const um=d.user_model,vt=um.visitor_type||{};
+    const umc=el("div",{class:"card"},cardhead("Visitor model"));
+    umc.append(el("div",{class:"row",style:"gap:7px;flex-wrap:wrap"},
+      personaPill("Falk: "+(vt.type||"?"),vt.type),
+      el("span",{class:"pill neutral"},"Pekarik: "+(um.experience_preference||"?")),
+      el("span",{class:"pill neutral"},"Style: "+(um.engagement_style||"?"))));
+    if(um.summary)umc.append(el("p",{class:"small",style:"margin:.5rem 0 0;line-height:1.55",html:mdInline(um.summary)}));
+    host.append(umc);
+  }
+  if(d.user_tag_affinity&&d.user_tag_affinity.length){
+    host.append(el("div",{class:"card"},cardhead("Visitor tag model"),
+      valueBars(d.user_tag_affinity.map(t=>[t.key,t.weight]))));
+  }
+  // ----- recommended items + explanation -----
+  const items=d.items||[];
+  host.append(el("div",{class:"eyebrow",style:"display:block;margin:14px 0 6px"},`Recommended items (${items.length})`));
+  for(const it of items){
+    const card=el("div",{class:"card"});
+    card.append(el("div",{class:"row",style:"gap:8px;align-items:baseline"},
+      el("b",{},`#${it.rank} `,it.title||it.id),
+      el("span",{class:"pill "+(it.role==="distractor"?"cold":"warm"),style:"font-size:11px"},it.role||"target"),
+      it.relevance_score!=null?el("span",{class:"small num mut"},"score "+fmt(it.relevance_score)):""));
+    const ov=it.tag_overlap||[];
+    card.append(el("div",{class:"eyebrow",style:"display:block;margin:9px 0 4px"},`Tag overlap visitor ↔ content (${ov.length})`));
+    if(ov.length)card.append(el("div",{class:"row",style:"gap:5px;flex-wrap:wrap"},
+      ...ov.map(o=>el("span",{class:"pill",style:"background:#5E735522;color:#5E7355;border-color:#5E735566;font-size:11px"},`${o.key}  ·  ${fmt(o.user_weight)}`))));
+    else card.append(el("div",{class:"small mut"},"no matching tags — recommended for other reasons (semantic similarity, exploration, geo, recency)"));
+    const others=(it.content_tags||[]).filter(t=>!ov.some(o=>o.key===t));
+    if(others.length)card.append(el("div",{class:"row",style:"gap:5px;flex-wrap:wrap;margin-top:5px"},
+      el("span",{class:"small mut",style:"margin-right:4px"},"other content tags:"),
+      ...others.map(t=>el("span",{class:"pill neutral",style:"font-size:11px;opacity:.6"},t))));
+    const bd=it.breakdown||{};
+    if(Object.keys(bd).length){
+      card.append(el("div",{class:"eyebrow",style:"display:block;margin:10px 0 4px"},"Why ranked here (score breakdown)"));
+      card.append(breakdownBar(bd));
+      card.append(legend());
+    }
+    host.append(card);
+  }
+}
+
 
 /* ===== COHORT: visitor search + table, segments below ===== */
 async function renderCohort(v){
@@ -588,9 +660,9 @@ async function renderTraffic(v){
     if(rows&&rows.length){
       const tbl=el("table");
       tbl.append(el("tr",{},el("th",{},"time"),el("th",{},"user"),el("th",{},"strategy"),el("th",{},"ranking"),el("th",{},"items"),el("th",{},"distractor")));
-      for(const r of rows)tbl.append(el("tr",{},
+      for(const r of rows)tbl.append(el("tr",{style:"cursor:pointer",title:"explain this recommendation",onclick:()=>openRec(r.request_id)},
         el("td",{class:"small mut num"},(r.ts||"").replace("T"," ").slice(0,19)),
-        el("td",{},el("button",{class:"userchip",title:"open visitor",onclick:()=>openUser(r.user_id,"profile")},r.user_id)),
+        el("td",{},el("button",{class:"userchip",title:"open visitor",onclick:(e)=>{e.stopPropagation();openUser(r.user_id,"profile");}},r.user_id)),
         el("td",{},el("span",{class:"pill "+(r.strategy||"warm")},r.strategy||"")),
         el("td",{class:"small mut"},r.ranking||""),el("td",{class:"num"},(r.items||[]).length),
         el("td",{class:"small mut"},r.distractor_id||"-")));
@@ -664,24 +736,82 @@ async function runRecommend(){
   }catch(e){out.append(el("div",{class:"card err"},String(e)));}
 }
 async function renderUser(v){
-  let exp;try{exp=await api(`/api/usermodel/explain?user_id=${encodeURIComponent($("#uid").value)}`);}catch(e){failCard(v,e);return;}
-  if(!exp){v.append(el("div",{class:"empty"},"No model for ",el("b",{},$("#uid").value),". Ingest some events for this user first."));return;}
+  const uid=$("#uid").value;
+  let exp,extra;
+  try{
+    exp=await api(`/api/usermodel/explain?user_id=${encodeURIComponent(uid)}`);
+    extra=await api(`/api/usermodel/extras?user_id=${encodeURIComponent(uid)}`).catch(()=>null);
+  }catch(e){failCard(v,e);return;}
+  if(!exp){v.append(el("div",{class:"empty"},"No model for ",el("b",{},uid),". Ingest some events for this user first."));return;}
   const vt=exp.visitor_type||{};
+  const model=(extra&&extra.model)||{}, surv=(extra&&extra.surveys)||{}, demo=(extra&&extra.demographics)||{};
+  // ----- persona header -----
   v.append(el("div",{class:"card lift"},
-    el("div",{class:"row"},personaPill("Falk: "+(vt.type||"?"),vt.type),
-      el("span",{class:"pill neutral"},"Pekarik: "+exp.experience_preference),
-      el("span",{class:"pill neutral"},exp.engagement_style),
-      exp.is_cold?el("span",{class:"pill cold"},"cold"):el("span",{class:"pill warm"},"warm")),
-    vt.rationale?el("p",{class:"mut small",style:"margin:.6rem 0 0"},"“"+vt.rationale+"” / confidence "+fmt(vt.confidence)):"",
-    el("p",{style:"margin:.55rem 0 0;line-height:1.6",html:mdInline(exp.summary)})));
-  if(exp.trajectory&&exp.trajectory.length)v.append(el("div",{class:"card"},el("b",{},"Trajectory   "),el("span",{class:"mut"},exp.trajectory.join("   then   "))));
-  if(exp.interests&&exp.interests.length)v.append(el("div",{class:"card"},cardhead("Interests"),valueBars(exp.interests.map(i=>[i.label+(i.evidence&&i.evidence.length?` / ${i.evidence.length} read`:""),i.weight]))));
-  if(exp.aversions&&exp.aversions.length)v.append(el("div",{class:"card"},cardhead("Aversions"),valueBars(exp.aversions.map(i=>[i.label,i.weight]),{signed:true})));
-  if(exp.cluster){const cl=exp.cluster;
-    v.append(el("div",{class:"card"},cardhead("Segment"),
-      el("div",{class:"small"},"dominant cluster "+(cl.dominant??cl.cluster)),
-      cl.membership?valueBars(Object.entries(cl.membership).map(([k,p])=>["cluster "+k,p]),{max:1}):"",
-      el("div",{class:"small mut",style:"margin-top:6px"},"shares: "+(cl.shared_tags||[]).map(t=>t.label).join(", "))));}
+    el("div",{class:"row",style:"gap:7px;flex-wrap:wrap"},
+      personaPill("Falk: "+(vt.type||"?"),vt.type),
+      el("span",{class:"pill neutral"},"Pekarik: "+(exp.experience_preference||"?")),
+      el("span",{class:"pill neutral"},"Style: "+(exp.engagement_style||"?")),
+      el("span",{class:"pill "+(exp.is_cold?"cold":"warm")},exp.is_cold?"cold":"warm")),
+    vt.rationale?el("div",{class:"small mut",style:"margin-top:8px"},vt.rationale):"",
+    exp.summary?el("p",{style:"margin:.55rem 0 0;line-height:1.6",html:mdInline(exp.summary)}):""));
+  // ----- demographics -----
+  const demoPairs=Object.entries(demo).filter(([,x])=>x!=null&&x!=="");
+  if(demoPairs.length)v.append(el("div",{class:"card"},cardhead("Demographics"),
+    el("div",{},...demoPairs.map(([k,x])=>el("div",{class:"row",style:"gap:8px;margin:3px 0"},
+      el("span",{class:"small mut",style:"width:160px"},k),
+      el("span",{class:"small"},Array.isArray(x)?x.join(", "):String(x)))))));
+  // ----- surveys (pre-survey + personalization) -----
+  const surveyRows=obj=>Object.entries(obj||{}).map(([q,a])=>el("div",{class:"row",style:"gap:8px;margin:3px 0"},
+    el("span",{class:"small mut",style:"width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap",title:q},q.replace(/^q:/,"")),
+    el("span",{class:"small"},Array.isArray(a)?a.join(", "):String(a))));
+  const sc=el("div",{class:"card"},cardhead("Surveys"));
+  sc.append(el("div",{class:"eyebrow",style:"display:block;margin-bottom:4px"},"Pre-survey / demographics "+(surv.completed_demographic?"✓ completed":"— not completed")));
+  sc.append((surv.demographic&&Object.keys(surv.demographic).length)?el("div",{},...surveyRows(surv.demographic)):el("div",{class:"small mut"},"no answers recorded"));
+  sc.append(el("div",{class:"eyebrow",style:"display:block;margin:12px 0 4px"},"Personalization survey "+(surv.completed_personalization?"✓ completed":"— not completed")));
+  sc.append((surv.personalization&&Object.keys(surv.personalization).length)?el("div",{},...surveyRows(surv.personalization)):el("div",{class:"small mut"},"no answers recorded"));
+  if(surv.other&&Object.keys(surv.other).length){
+    sc.append(el("div",{class:"eyebrow",style:"display:block;margin:12px 0 4px"},"Other survey answers"));
+    sc.append(el("div",{},...surveyRows(surv.other)));
+  }
+  v.append(sc);
+  // ----- dynamic user model -----
+  const dm=el("div",{class:"card"},cardhead("Dynamic user model"));
+  if(model.counts)dm.append(el("div",{class:"small mut",style:"margin-bottom:9px"},
+    `${model.counts.viewed||0} viewed · ${model.counts.positives||0} liked · ${model.counts.negatives||0} disliked`+(model.is_cold?"  (cold start)":"")));
+  if(model.tag_affinity&&model.tag_affinity.length){
+    dm.append(el("div",{class:"eyebrow",style:"display:block;margin-bottom:4px"},"Tag affinities — what the visitor leans toward"));
+    dm.append(valueBars(model.tag_affinity.map(t=>[t.key,t.weight])));
+  }
+  if(model.tag_aversion&&model.tag_aversion.length){
+    dm.append(el("div",{class:"eyebrow",style:"display:block;margin:12px 0 4px"},"Tag aversions — what to avoid"));
+    dm.append(valueBars(model.tag_aversion.map(t=>[t.key,t.weight]),{signed:true}));
+  }
+  const beh=Object.entries(model.behavior||{}).filter(([,x])=>typeof x==="number");
+  if(beh.length){
+    dm.append(el("div",{class:"eyebrow",style:"display:block;margin:12px 0 4px"},"Engagement behaviour"));
+    dm.append(el("div",{class:"row",style:"gap:16px;flex-wrap:wrap"},...beh.map(([k,x])=>
+      el("span",{class:"small"},el("span",{class:"mut"},k+": "),fmt(x)))));
+  }
+  v.append(dm);
+  // ----- content engaged positively, with its tags (basis for inferred interest) -----
+  if(model.liked_content&&model.liked_content.length){
+    const lc=el("div",{class:"card"},cardhead("Engaged positively with"),
+      el("div",{class:"small mut",style:"margin-bottom:8px"},"content the visitor liked and the tags it carries — the basis for the inferred interests"));
+    for(const it of model.liked_content){
+      lc.append(el("div",{style:"padding:7px 0;border-top:1px solid var(--line)"},
+        el("div",{class:"row",style:"gap:8px"},el("b",{class:"small"},it.title||it.id),el("span",{class:"small num mut"},"weight "+fmt(it.weight))),
+        el("div",{class:"row",style:"gap:5px;flex-wrap:wrap;margin-top:5px"},
+          ...((it.tags||[]).length?it.tags.map(t=>el("span",{class:"pill neutral",style:"font-size:11px"},t)):[el("span",{class:"small mut"},"no tags")]))));
+    }
+    v.append(lc);
+  }
+  // ----- trajectory + evidence interests/aversions (kept from the original profile) -----
+  if(exp.trajectory&&exp.trajectory.length)v.append(el("div",{class:"card"},cardhead("Trajectory"),
+    el("div",{class:"small"},exp.trajectory.join("   →   "))));
+  if(exp.interests&&exp.interests.length)v.append(el("div",{class:"card"},cardhead("Interests (with evidence)"),
+    valueBars(exp.interests.map(i=>[i.label+(i.evidence&&i.evidence.length?`  ·  ${i.evidence.length} item(s)`:""),i.weight]))));
+  if(exp.aversions&&exp.aversions.length)v.append(el("div",{class:"card"},cardhead("Aversions"),
+    valueBars(exp.aversions.map(i=>[i.label,i.weight]),{signed:true})));
 }
 
 async function renderHistory(v){
@@ -1240,8 +1370,10 @@ function applyHash(){
   const h=location.hash||"";
   cfgEdit=false;                              // leaving (or re-entering) any view auto-cancels Config edits
   const um=h.match(/^#\/user\/([^/]+)(?:\/([^/]+))?/);
-  if(um){userCtx={id:decodeURIComponent(um[1]),sub:um[2]||"profile"};$("#uid").value=userCtx.id;paint();return;}
-  userCtx=null;const s=h.replace(/^#\/?/,"");const n=BY_SLUG[s];
+  const rm=h.match(/^#\/rec\/([^/]+)/);
+  if(rm){recCtx=decodeURIComponent(rm[1]);userCtx=null;paint();return;}
+  if(um){recCtx=null;userCtx={id:decodeURIComponent(um[1]),sub:um[2]||"profile"};$("#uid").value=userCtx.id;paint();return;}
+  recCtx=null;userCtx=null;const s=h.replace(/^#\/?/,"");const n=BY_SLUG[s];
   if(n){current=n;paint();}else{setTab(current);}
 }
 

--- a/src/ai_engine/recsys/survey.py
+++ b/src/ai_engine/recsys/survey.py
@@ -11,6 +11,10 @@ canonical taxonomy label (e.g. "Forced Labor") so it matches content tags 1:1.
 from __future__ import annotations
 from typing import Optional
 
+# Origins with their own country-specific content tags. Any other nationality rolls
+# up to the `International` tag (see survey_affinity). Compared casefolded.
+CORE_COUNTRIES = {"netherlands", "germany", "poland"}
+
 SURVEY_EVENTS = ("SURVEY_SUBMITTED", "SURVEY_ANSWERED")
 # events whose answers/traits seed demographics + persona affinity. IDENTIFY is the
 # RudderStack identify call the app sends AFTER the survey (traits = persona).
@@ -97,6 +101,21 @@ def extract_demographics(answers: dict) -> dict:
     return out
 
 
+def split_survey_answers(answers: dict) -> dict:
+    """Group raw survey answers by origin survey for the holistic visitor profile:
+    demographic (presurvey) vs personalization vs anything else. Keys are the raw
+    question ids; values are the raw answers."""
+    demo_qids = set(_AGE_QIDS) | set(_GENDER_QIDS) | set(_NAT_QIDS) | set(_PROVINCE_QIDS) | set(_CONN_QIDS)
+    pers_qids = set(_PERSONALIZATION)
+    demographic: dict = {}
+    personalization: dict = {}
+    other: dict = {}
+    for k, v in (answers or {}).items():
+        bucket = demographic if k in demo_qids else personalization if k in pers_qids else other
+        bucket[k] = v
+    return {"demographic": demographic, "personalization": personalization, "other": other}
+
+
 def survey_affinity(answers: dict) -> dict[str, float]:
     """Survey answers -> {tag_key: weight} in the content taxonomy (the persona)."""
     out: dict[str, float] = {}
@@ -108,12 +127,18 @@ def survey_affinity(answers: dict) -> dict[str, float]:
         if v in _GENDER:
             out[f"person_who.gender_and_age:{_GENDER[v]}"] = 0.3
     for v in _vals(answers, *_NAT_QIDS):
-        out[f"person_who.city_village_country:From: {str(v).replace('_', ' ').title()}"] = 0.4
-    # visitor's NL province -> the SAME facet the content province tags use, so score_tag
-    # boosts same-province stories. Keep the label as-is (hyphens matter: "Zuid-Holland").
+        country = str(v).replace("_", " ").title()
+        out[f"person_who.city_village_country:From: {country}"] = 0.4
+        # rollup: visitors whose origin is not one of the prominently-tagged
+        # countries also match content tagged `International` (the complement set).
+        if country.strip().casefold() not in CORE_COUNTRIES:
+            out["person_who.city_village_country:International"] = 0.3
+    # visitor's NL province -> person_who.province_netherlands, the facet the content
+    # province tags use per the authoritative taxonomy (tags.json). score_tag boosts
+    # same-province stories. Keep the label as-is (hyphens matter: "Zuid-Holland").
     for v in _vals(answers, *_PROVINCE_QIDS):
         if v:
-            out[f"place_where.province_netherlands:{str(v).strip()}"] = 0.5
+            out[f"person_who.province_netherlands:{str(v).strip()}"] = 0.5
 
     # explicit preference questions: value IS the taxonomy label -> strong weight.
     # canonicalize the value so slug/underscore/spelling variants still match content.

--- a/src/ai_engine/recsys/taxonomy.py
+++ b/src/ai_engine/recsys/taxonomy.py
@@ -13,4 +13,5 @@ from memorise_taxonomy import (  # noqa: F401
     normalize_label,
     review_vocab,
     to_tag,
+    to_tags,
 )

--- a/src/ai_engine/recsys/taxonomy.py
+++ b/src/ai_engine/recsys/taxonomy.py
@@ -1,0 +1,16 @@
+"""Re-export of the shared :mod:`memorise_taxonomy` package.
+
+The match-key normalization is now a single source of truth in ``memorise-taxonomy``
+so the survey side (here) and the content-ingest side (omeka-tools / content-engine)
+can never drift. This shim keeps existing ``ai_engine.recsys.taxonomy`` imports working.
+"""
+from memorise_taxonomy import (  # noqa: F401
+    ALIASES,
+    DEFAULT_FACET,
+    FacetAssignment,
+    assign_facet,
+    normalize_key,
+    normalize_label,
+    review_vocab,
+    to_tag,
+)

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,30 @@
+"""Persona<->content tag match normalization, and the survey-side facet fixes."""
+from ai_engine.recsys.taxonomy import normalize_key, normalize_label
+from ai_engine.recsys.survey import survey_affinity, CORE_COUNTRIES
+
+
+def test_normalize_is_symmetric_across_drift():
+    # the survey side and the content side must produce the same key for these.
+    assert normalize_label("Personal Stories") == normalize_label("personal stories")
+    assert normalize_label("Sport & Theatre") == normalize_label("Sport & Theater")
+    assert normalize_label("Düsseldorf") == "dusseldorf"
+    assert normalize_key("THEME_WHAT:Forced Labour") == "theme_what:forced labor"
+
+
+def test_province_uses_person_who_facet_per_authority():
+    # tags.json puts Province under person_who, not place_where.
+    aff = survey_affinity({"q:province": "Drenthe"})
+    assert any(k.startswith("person_who.province_netherlands:") for k in aff)
+    assert not any(k.startswith("place_where.province_netherlands:") for k in aff)
+
+
+def test_non_core_nationality_emits_international_rollup():
+    aff = survey_affinity({"q:nationality": "spain"})
+    assert "person_who.city_village_country:From: Spain" in aff
+    assert "person_who.city_village_country:International" in aff
+
+
+def test_core_nationality_does_not_emit_international():
+    assert "netherlands" in CORE_COUNTRIES
+    aff = survey_affinity({"q:nationality": "netherlands"})
+    assert not any(k.endswith(":International") for k in aff)


### PR DESCRIPTION
Faceted survey↔content tag matching via the shared memorise-taxonomy normalizer. Fixes the root cause where content tags had no facets (every tag score was 0). Validated end-to-end: ingested Westerbork collection 7 into Qdrant, survey-derived keys retrieve real content (0→matches).

Part of the cross-repo tag-taxonomy work (memorise-taxonomy, ai-engine, omeka-tools, content-engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)