### PR TITLE
fix: vendor memorise_taxonomy into src (fix recsys 0.6.2 CrashLoopBackOff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# vendored taxonomy data (needed at runtime; the bare "data" rule above would drop it)
+!src/memorise_taxonomy/data/
+!src/memorise_taxonomy/data/tags.json

--- a/src/memorise_taxonomy/VENDORED.md
+++ b/src/memorise_taxonomy/VENDORED.md
@@ -1,0 +1,23 @@
+# VENDORED — do not edit here
+
+This is a vendored copy of the `memorise_taxonomy` package
+(https://github.com/ai-engine-memorise/memorise-taxonomy), copied into `src/` so
+the recsys Docker image can `import memorise_taxonomy` without installing a
+private, unpublished package.
+
+Why vendored: `recsys/taxonomy.py` imports `memorise_taxonomy` (e.g. `to_tags`)
+at module load. The package is a private repo, not on any index, and the recsys
+Docker build context is `ai-engine/` only — so it cannot be pip-installed or
+`COPY`'d from a sibling path. Without it, the container crashes on startup
+(ImportError -> CrashLoopBackOff). The image already has `PYTHONPATH=/app/src` and
+`COPY src ./src`, so dropping the package here makes it importable with no
+Dockerfile change.
+
+Source of truth is the upstream repo. To re-sync after upstream changes:
+
+    cp -r ../memorise-taxonomy/src/memorise_taxonomy/{__init__.py,taxonomy.py,data} \
+          ai-engine/src/memorise_taxonomy/
+
+Better long-term fix: publish `memorise-taxonomy` to a package index (or a private
+GHCR/GitLab pip index), add `"memorise-taxonomy>=X.Y"` to `Dockerfile.recsys`, and
+delete this vendored copy.

--- a/src/memorise_taxonomy/__init__.py
+++ b/src/memorise_taxonomy/__init__.py
@@ -1,0 +1,28 @@
+"""Shared MEMORISE tag taxonomy & match normalization.
+
+Single source of truth imported by ai-engine (survey side), omeka-tools and
+content-engine (content-ingest side). See ``taxonomy`` for the implementation.
+"""
+from .taxonomy import (
+    ALIASES,
+    DEFAULT_FACET,
+    FacetAssignment,
+    assign_facet,
+    normalize_key,
+    normalize_label,
+    review_vocab,
+    to_tag,
+    to_tags,
+)
+
+__all__ = [
+    "ALIASES",
+    "DEFAULT_FACET",
+    "FacetAssignment",
+    "assign_facet",
+    "normalize_key",
+    "normalize_label",
+    "review_vocab",
+    "to_tag",
+    "to_tags",
+]

--- a/src/memorise_taxonomy/data/tags.json
+++ b/src/memorise_taxonomy/data/tags.json
@@ -1,0 +1,743 @@
+{
+ "title": "Tagging Omeka Content for the Recommender System",
+ "source": "Final tags (adapted from VHA tags)",
+ "notes": [
+  "Titles and descriptions in brackets",
+  "Tags separated by commas",
+  "In the first section there's a main tag and sub-tag, in some sections only sub-tags",
+  "Tags added after drift-check vs Westerbork collection 7 (2026-06-22): map, camp-area entrances/guard towers/storage barrack/warehouse/commander's house, survivor/resistance fighter/child girl/child boy/collaborators/patients/POWs, provinces Brabant/Buitenland, mothertongues Frisian/English."
+ ],
+ "dimensions": [
+  {
+   "key": "theme_what",
+   "label": "Theme main tags (What)",
+   "description": "Sub-tag of what is described in the item",
+   "main_tags": [
+    {
+     "tag": "Adaptation and Survival",
+     "subtags": [
+      "adaptation",
+      "camp adaptation methods",
+      "hiding adaptation methods",
+      "survival explanations",
+      "decisions",
+      "survival",
+      "uprising",
+      "partisans",
+      "black market",
+      "hiding place",
+      "occupation",
+      "trial"
+     ]
+    },
+    {
+     "tag": "Aid and Protection",
+     "subtags": [
+      "aid giving",
+      "false document provision",
+      "shelter provision",
+      "sustenance provision",
+      "migration assistance",
+      "protection",
+      "protection papers",
+      "Palestine certificates",
+      "exchange",
+      "money provision"
+     ]
+    },
+    {
+     "tag": "Awareness and Reflection",
+     "subtags": [
+      "Holocaust awareness",
+      "reflections",
+      "post-World War II reflections",
+      "bystander",
+      "witness",
+      "civilian",
+      "illusion",
+      "propaganda"
+     ]
+    },
+    {
+     "tag": "Brutality and Killings",
+     "subtags": [
+      "killings",
+      "executions",
+      "mass executions",
+      "brutal treatment",
+      "shootings",
+      "violence",
+      "violent attacks",
+      "humiliation",
+      "beatings",
+      "murder",
+      "Kristallnacht",
+      "abuse",
+      "death marches"
+     ]
+    },
+    {
+     "tag": "Camp Procedures",
+     "subtags": [
+      "camp procedures",
+      "camp intake procedures",
+      "selections",
+      "prisoner identification",
+      "prisoner identification numbers",
+      "prisoner insignia",
+      "prisoner of war camps (generic)",
+      "forced tattoos",
+      "quarantine",
+      "delousing",
+      "dispossession",
+      "punishment",
+      "self-administration",
+      "registration"
+     ]
+    },
+    {
+     "tag": "Cultural and Creative Activities",
+     "subtags": [
+      "creative works",
+      "original works",
+      "crafts",
+      "fine arts",
+      "performing arts",
+      "musical recitals",
+      "music",
+      "literary recitals",
+      "cultural activities",
+      "camp/ghetto/hiding-related cultural activities",
+      "education",
+      "camp/refugee camp education",
+      "vocational training",
+      "sports",
+      "gymnastics",
+      "football",
+      "handball",
+      "boxing",
+      "cinema",
+      "cabaret",
+      "theatre"
+     ]
+    },
+    {
+     "tag": "Daily Life",
+     "subtags": [
+      "Roll-call",
+      "farming",
+      "classes",
+      "learning",
+      "teaching",
+      "acts of resistance",
+      "holidays",
+      "property",
+      "education",
+      "school",
+      "birthdays",
+      "working"
+     ]
+    },
+    {
+     "tag": "Deaths and Mortality",
+     "subtags": [
+      "deaths",
+      "post-liberation deaths",
+      "suicides",
+      "corpses",
+      "corpse disposal",
+      "burial sites",
+      "mass graves",
+      "crematorium",
+      "corpse detail",
+      "extermination"
+     ]
+    },
+    {
+     "tag": "Deportation and Transport",
+     "subtags": [
+      "deportation experiences",
+      "transfer experiences",
+      "transfer conditions",
+      "transfers",
+      "means of transport",
+      "trains",
+      "freight trains",
+      "rescue transports",
+      "Kasztner transport",
+      "exchange transport",
+      "deportation",
+      "transport",
+      "bus"
+     ]
+    },
+    {
+     "tag": "Discrimination",
+     "subtags": [
+      "anti-Jewish measures",
+      "discriminatory measures",
+      "antisemitism",
+      "Nazi propaganda",
+      "arrests",
+      "anti-Jewish arrests",
+      "roundups",
+      "anti-Jewish roundups",
+      "personal prejudice",
+      "anti-Romani",
+      "anti-Romani arrests",
+      "homophobia",
+      "racism",
+      "xenophobia",
+      "sexism",
+      "denouncement"
+     ]
+    },
+    {
+     "tag": "DP Camps",
+     "subtags": [
+      "displaced persons camp administration/experiences",
+      "refugee camp experiences",
+      "central committee",
+      "Jewish DP camp",
+      "Polish DP camp",
+      "Kazet theatre"
+     ]
+    },
+    {
+     "tag": "Family",
+     "subtags": [
+      "family life",
+      "family histories",
+      "family homes",
+      "wartime family interactions",
+      "ghetto family interactions",
+      "marriages",
+      "survivor marriages",
+      "children",
+      "siblings",
+      "parents",
+      "orphans",
+      "pregnancy",
+      "foster family",
+      "giving birth"
+     ]
+    },
+    {
+     "tag": "Flight and Migration",
+     "subtags": [
+      "flight",
+      "flight preparations",
+      "flight to the UK",
+      "migration decisions",
+      "migration experiences",
+      "migration policies",
+      "migration preparations",
+      "Kindertransport",
+      "refugee",
+      "hiding",
+      "aliyah",
+      "emigration to Palestine",
+      "escape",
+      "Palestine training program",
+      "kibbutz"
+     ]
+    },
+    {
+     "tag": "Food and Hunger",
+     "subtags": [
+      "food",
+      "camp food",
+      "ghetto food",
+      "food acquisition",
+      "hunger",
+      "food rationing",
+      "kitchen"
+     ]
+    },
+    {
+     "tag": "Forced Labor",
+     "subtags": [
+      "forced labor activities/conditions",
+      "forced labor battalion experiences",
+      "agricultural/armament/construction/factory/medical/textile/translation forced labor",
+      "personal property sorting forced labor",
+      "work detail",
+      "workshops"
+     ]
+    },
+    {
+     "tag": "Guarding",
+     "subtags": [
+      "guards",
+      "SS",
+      "SD",
+      "watch tower",
+      "dog",
+      "barbed wire fence",
+      "camp commander",
+      "Netherlands Marechaussee",
+      "NSB",
+      "kapo",
+      "prisoner police",
+      "perpetrator",
+      "collaboration",
+      "corruption",
+      "Dutch military police",
+      "Jewish Order Service (OD)"
+     ]
+    },
+    {
+     "tag": "Health and Diseases",
+     "subtags": [
+      "health",
+      "physical health",
+      "diseases",
+      "epidemics",
+      "typhus",
+      "medical care",
+      "hospitals",
+      "camp hospital",
+      "medical staff",
+      "dentist",
+      "doctor",
+      "nurse",
+      "illness",
+      "pediatrician",
+      "medicine",
+      "maternity ward"
+     ]
+    },
+    {
+     "tag": "Liberation",
+     "subtags": [
+      "liberation",
+      "camp liberation",
+      "ghetto liberation",
+      "liberation participation",
+      "forced march liberation",
+      "transfer liberation",
+      "liberator",
+      "British Army",
+      "Canadian troops",
+      "Soviet troops",
+      "Jewish brigade",
+      "Allied forces"
+     ]
+    },
+    {
+     "tag": "Living Conditions",
+     "subtags": [
+      "housing conditions",
+      "camp/hiding-related housing conditions",
+      "living conditions",
+      "camp/ghetto/hiding/refugee camp living conditions",
+      "environmental conditions",
+      "bunk beds",
+      "weather",
+      "seasons",
+      "over-crowdedness"
+     ]
+    },
+    {
+     "tag": "Jewish Life",
+     "subtags": [
+      "Jewish life",
+      "Jewish culture",
+      "Yiddish culture",
+      "Yiddish language",
+      "Hebrew",
+      "Shabbat",
+      "Jewish holidays",
+      "Hanukkah"
+     ]
+    },
+    {
+     "tag": "Political Activities",
+     "subtags": [
+      "Communism",
+      "Zionism",
+      "resistance activities",
+      "resistance fighters",
+      "Jewish Council"
+     ]
+    },
+    {
+     "tag": "Religion",
+     "subtags": [
+      "prayers",
+      "Jewish prayers",
+      "religious observances",
+      "religious objects",
+      "religious holidays",
+      "rabbi",
+      "priest",
+      "Catholicism",
+      "Christianity",
+      "Judaism",
+      "synagogue",
+      "church",
+      "baptism"
+     ]
+    },
+    {
+     "tag": "Sanitary Conditions",
+     "subtags": [
+      "Delousing",
+      "showers",
+      "camp sanitary conditions",
+      "lice"
+     ]
+    },
+    {
+     "tag": "Social Relations",
+     "subtags": [
+      "social relations",
+      "camp/hiding-related social relations",
+      "friends",
+      "solidarity",
+      "positive encounters",
+      "friendship",
+      "helping"
+     ]
+    },
+    {
+     "tag": "Thoughts and Feelings",
+     "subtags": [
+      "psychological reactions",
+      "camp/liberation-related psychological reactions",
+      "emotions",
+      "feelings",
+      "thoughts",
+      "mental health",
+      "physical sensations",
+      "suffering",
+      "trauma",
+      "joy",
+      "happiness",
+      "relief",
+      "love",
+      "anger",
+      "guilt"
+     ]
+    }
+   ]
+  },
+  {
+   "key": "medium_what",
+   "label": "Medium (What)",
+   "description": "Sub-tags to describe the medium of the item in Omeka",
+   "subtags": [
+    "Photograph",
+    "artwork",
+    "object",
+    "physical document",
+    "film",
+    "audio testimony",
+    "written testimony",
+    "text",
+    "biographical text",
+    "map"
+   ],
+   "clarifications": {
+    "Photograph": "inc. stills from a film",
+    "artwork": "inc. drawing, painting, sculpture",
+    "physical document": "i.e. letter, newspaper cutout",
+    "written testimony": "1st person account i.e. diary entry, memoire",
+    "text": "written by 3rd party i.e. historians, staff / researchers",
+    "biographical text": "text centering a person"
+   }
+  },
+  {
+   "key": "place_where",
+   "label": "Place (Where)",
+   "description": "Tags for areas/regions that an item relates to",
+   "groups": [
+    {
+     "label": "Camp areas",
+     "subtags": [
+      "Barracks",
+      "buildings",
+      "camp entrance",
+      "infirmary",
+      "internment camp",
+      "labour camp",
+      "Neutrals' camp",
+      "Prisoners of War camp",
+      "Special camp",
+      "tent camp",
+      "Star camp",
+      "Men's camp",
+      "Women's camp",
+      "Hungarians' camp",
+      "exchange camp",
+      "punishment barracks",
+      "kitchens",
+      "Schattenberg camp farm",
+      "topography",
+      "water treatment plant",
+      "aircraft scrapyard",
+      "dentist",
+      "laboratory",
+      "living barracks",
+      "theatre and registration",
+      "orphanage",
+      "commander's house",
+      "train tracks",
+      "train platform",
+      "narrow-gauge train",
+      "greenhouse",
+      "garden",
+      "maternity ward",
+      "camp main road",
+      "landscape",
+      "railway line",
+      "watch tower",
+      "Heidelager",
+      "camp boundary",
+      "playground",
+      "warehouse",
+      "visiting barrack",
+      "boiler room",
+      "entrance",
+      "guard towers",
+      "storage barrack"
+     ]
+    },
+    {
+     "label": "Barrack number",
+     "format": "Barrack x, Barrack x-x",
+     "examples": [
+      "barrack 35",
+      "barracks 65-67"
+     ]
+    },
+    {
+     "label": "Transit destinations (arrived from, deported to)",
+     "format": [
+      "Arrived from: x",
+      "Deported to: x"
+     ],
+     "note": "Tag name of camp where person was staying (and deported to)",
+     "examples": [
+      "Arrived from: Camp Vught",
+      "Deported to: Auschwitz-Birkenau"
+     ]
+    }
+   ]
+  },
+  {
+   "key": "person_who",
+   "label": "Person (Who)",
+   "description": "Tags for biographical information of the author/creator/described person",
+   "groups": [
+    {
+     "label": "Reason for imprisonment",
+     "subtags": [
+      "Victim",
+      "prisoner",
+      "Disabled and sick people",
+      "homosexuals",
+      "Italian military internees",
+      "Jehova's witnesses",
+      "Jewish",
+      "Polish Home Army",
+      "political persecutee",
+      "political prisoner",
+      "prisoners of war",
+      "PoW",
+      "Roma and Sinti",
+      "socially persecuted people",
+      "'S-inmates'",
+      "internees",
+      "Moluccan",
+      "Indo-Dutch",
+      "survivor",
+      "resistance fighter",
+      "child girl",
+      "child boy",
+      "collaborators",
+      "patients",
+      "POWs"
+     ]
+    },
+    {
+     "label": "Age group",
+     "subtags": [
+      "child",
+      "adult",
+      "elderly",
+      "age 16-18",
+      "age 18-24",
+      "age 25-34",
+      "age 35-44",
+      "age 45-54",
+      "age 55-64",
+      "age 65-74",
+      "age 75-84",
+      "age 85+"
+     ],
+     "note": "Child = >18; Adult = 18-64; Elderly = 65-85+"
+    },
+    {
+     "label": "Gender and age",
+     "subtags": [
+      "Male",
+      "female",
+      "non-binary"
+     ]
+    },
+    {
+     "label": "Mothertongue",
+     "subtags": [
+      "Dutch",
+      "German",
+      "Polish",
+      "Hungarian",
+      "Yiddish",
+      "Frisian",
+      "English"
+     ],
+     "note": "E.g."
+    },
+    {
+     "label": "Province (Netherlands)",
+     "subtags": [
+      "Noord-Holland",
+      "Zuid-Holland",
+      "Utrecht",
+      "Gelderland",
+      "Overijssel",
+      "Flevoland",
+      "Drenthe",
+      "Friesland",
+      "Groningen",
+      "Limburg",
+      "Noord-Brabant",
+      "Zeeland",
+      "Brabant",
+      "Buitenland"
+     ]
+    },
+    {
+     "label": "City/village & country",
+     "format": [
+      "Born in: x",
+      "Lived in x",
+      "From: x"
+     ],
+     "note": "Tag name of city/village and country of origin and/or where they lived before deportation",
+     "examples": [
+      "Born in: Haren",
+      "Lived in: Amsterdam",
+      "From: Germany"
+     ]
+    }
+   ]
+  },
+  {
+   "key": "time_when",
+   "label": "Time (When)",
+   "description": "Tags for time period of camp (additional to years of reference in Omeka)",
+   "groups": [
+    {
+     "label": "Time period",
+     "subtags": [
+      "Refugee camp",
+      "Transit camp",
+      "Internment Camp",
+      "Schattenberg period",
+      "contemporary time",
+      "memorial museum"
+     ]
+    }
+   ]
+  },
+  {
+   "key": "theme_how",
+   "label": "Theme tags (How)",
+   "description": "Research-related tags. Used for AI engine Storylines & Aliisa's research; focus on content of material but also how it is produced. More than one tag may be used.",
+   "groups": [
+    {
+     "label": "AI Engine themes Westerbork",
+     "source": "From Bas",
+     "subtags": [
+      "\"Sports\" & \"Leisure\"",
+      "Sport & Theatre",
+      "Resistance",
+      "Jewish Culture & Religion",
+      "Sinti & Roma",
+      "Perpetrators",
+      "Perpetrators & Bystanders"
+     ]
+    },
+    {
+     "label": "Type of stores",
+     "source": "From Bas",
+     "subtags": [
+      "Personal Stories",
+      "Historical Context",
+      "Anecdotes",
+      "Centered around an Artifact"
+     ]
+    },
+    {
+     "label": "Daily Life & Camp Experience",
+     "definition": "Describing experiences of (mainly) prisoners/survivors, 3rd person account, less personal. Items that describe: routines, labour, social dynamics, survival strategies.",
+     "tagging_rule": "no sub tags, tag as Daily Life & Camp Experience"
+    },
+    {
+     "label": "Historical Context & Overview",
+     "definition": "Items that describe: events shaping the history, use of the site, power structures. Fact-based texts (written by memorial / historians), describing objectively e.g. historical overview, organisation of the site, changes of functions based on historical events.",
+     "tagging_rule": "no sub tags, tag as Historical Context & Overview"
+    },
+    {
+     "label": "Reflections & Encounters",
+     "definition": "Items that relate to: biographies, relationships, witness testimonies, philosophical reflections, quotes. Personal, humanised, text close to the witness / survivor (1st person account, or describing a personal story).",
+     "tagging_rule": "no sub tags, tag as Reflections & Encounters"
+    }
+   ]
+  },
+  {
+   "key": "language_how",
+   "label": "Language tags (How)",
+   "description": "Each item text will be given 5 keywords based on a sentiment analysis. All found keywords are listed below.",
+   "groups": [
+    {
+     "label": "Tone of Text",
+     "subtags": [
+      "Somber (tone)",
+      "tragic (tone)",
+      "reflective (tone)",
+      "tragic irony (tone)",
+      "historical (tone)",
+      "poignant (tone)",
+      "mournful (tone)",
+      "serious (tone)",
+      "compassionate (tone)",
+      "documentary (tone)",
+      "humane (tone)",
+      "objective (tone)",
+      "understated (tone)",
+      "descriptive (tone)",
+      "nuanced (tone)",
+      "analytical (tone)",
+      "bittersweet (tone)",
+      "anecdotal (tone)",
+      "humanizing (tone)",
+      "informational (tone)",
+      "critical (tone)",
+      "hopeful (tone)",
+      "unsettling (tone)",
+      "subtle irony (tone)"
+     ],
+     "clarifications": {
+      "poignant (tone)": "emotionally moving, personal, touching",
+      "humane (tone)": "empathy, moral care in inhumane times",
+      "anecdotal (tone)": "storytelling",
+      "humanizing (tone)": "personal, real, relatable"
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/src/memorise_taxonomy/taxonomy.py
+++ b/src/memorise_taxonomy/taxonomy.py
@@ -1,0 +1,259 @@
+"""Single source of truth for MEMORISE tag matching.
+
+The recommender matches a visitor's survey-derived tags against content tags by
+string equality on the key ``"facet:label"``. The survey side (ai-engine) and the
+content-ingest side (omeka-tools / content-engine) must produce identical keys for
+the same concept or the match silently drops to zero. This package is that shared
+logic, imported by all three repos so the two sides can never drift.
+
+Two concerns:
+
+* ``normalize_label`` / ``normalize_key`` -- the canonical match form (casing,
+  whitespace, accents, separators, spelling, typo aliases).
+* ``assign_facet`` / ``to_tag`` -- map a flat Omeka tag string to its facet, driven
+  by the authoritative ``data/tags.json`` ("Final tags, adapted from VHA tags").
+"""
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+_TAGS_JSON = Path(__file__).with_name("data") / "tags.json"
+
+# --- canonical match form --------------------------------------------------------
+
+# substring spelling unifications (British/US + common in-collection typos), so they
+# also fix compounds like "construction forced labour".
+_SPELL: list[tuple[str, str]] = [
+    ("labour", "labor"),
+    ("theatre", "theater"),
+    ("tranport", "transport"),
+]
+
+# confirmed divergences normalization alone can't reconcile: data-entry typos,
+# Dutch<->English duplicates, wording variants. normalized -> normalized.
+ALIASES: dict[str, str] = {
+    "from: united kindom": "from: united kingdom",
+    "barak": "barrack",
+    "transitcamp": "transit camp",
+    "commandant's house": "commander's house",
+    "commanders house": "commander's house",
+    "joods leven": "jewish life",
+    "daders & omstanders": "perpetrators & bystanders",
+    "verzet": "resistance",
+    "volksdeutche": "volksdeutsche",
+    "death and mortality": "deaths and mortality",
+    "death": "deaths and mortality",
+    "social dynamics": "social relations",
+    "biography": "biographical text",
+    "personal story": "personal stories",
+    "photography": "photograph",
+    "prisoners": "prisoner",
+}
+
+_WS = re.compile(r"[\s_\-]+")
+_QUOTES = str.maketrans({"“": '"', "”": '"', "‘": "'", "’": "'"})
+
+
+def _base_normalize(label: str) -> str:
+    s = str(label).translate(_QUOTES)
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.casefold().strip()
+    for a, b in _SPELL:
+        s = s.replace(a, b)
+    return _WS.sub(" ", s).strip()
+
+
+def normalize_label(label: str) -> str:
+    """Raw label -> canonical match form (base normalization + alias resolution)."""
+    s = _base_normalize(label)
+    return ALIASES.get(s, s)
+
+
+def normalize_key(key: str) -> str:
+    """Normalize a ``"facet:label"`` key. Splits on the FIRST colon so labels that
+    contain a colon (``"From: Spain"``) survive. The facet is a stable machine key --
+    only casefolded, not separator-collapsed."""
+    facet, sep, label = key.partition(":")
+    if not sep:
+        return normalize_label(key)
+    return f"{facet.strip().casefold()}:{normalize_label(label)}"
+
+
+# --- AiAR machine tags -----------------------------------------------------------
+
+def _decode_aiar(tag: str) -> str:
+    """``AiARLocationBarrack56`` -> ``Barrack 56`` (the app emits camelCase AR tags
+    for the same camp areas curators tag by hand)."""
+    if tag[:12].lower() == "aiarlocation":
+        rest = tag[12:]
+        rest = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", rest)
+        rest = re.sub(r"(?<=[A-Za-z])(?=\d)", " ", rest)
+        return rest.strip()
+    return tag
+
+
+# --- facet taxonomy, loaded from the authoritative tags.json ---------------------
+
+# dimension+group -> facet key, aligned with the survey side (ai_engine.recsys.survey)
+# so survey-derived keys and content keys agree.
+_GROUP_FACET: dict[tuple[str, str], str] = {
+    ("person_who", "Reason for imprisonment"): "person_who.reason_for_imprisonment",
+    ("person_who", "Age group"): "person_who.age_group",
+    ("person_who", "Gender and age"): "person_who.gender_and_age",
+    ("person_who", "Mothertongue"): "person_who.mothertongue",
+    ("person_who", "Province (Netherlands)"): "person_who.province_netherlands",
+    ("person_who", "City/village & country"): "person_who.city_village_country",
+    ("place_where", "Camp areas"): "place_where.camp_areas",
+    ("place_where", "Barrack number"): "place_where.camp_areas",
+    ("place_where", "Transit destinations (arrived from, deported to)"): "place_where.transit_destinations",
+    ("time_when", "Time period"): "time_when.time_period",
+    ("theme_how", "AI Engine themes Westerbork"): "theme_how.ai_engine_themes",
+    ("theme_how", "Type of stores"): "theme_how.type_of_stores",
+    ("theme_how", "Daily Life & Camp Experience"): "theme_how.type_of_stores",
+    ("theme_how", "Historical Context & Overview"): "theme_how.type_of_stores",
+    ("theme_how", "Reflections & Encounters"): "theme_how.type_of_stores",
+}
+
+_PREFIXES: list[tuple[str, str]] = [
+    ("from:", "person_who.city_village_country"),
+    ("born in:", "person_who.city_village_country"),
+    ("lived in:", "person_who.city_village_country"),
+    ("live in:", "person_who.city_village_country"),
+    ("deported to:", "place_where.transit_destinations"),
+    ("arrived from:", "place_where.transit_destinations"),
+    ("transported to:", "place_where.transit_destinations"),
+    ("transferred to:", "place_where.transit_destinations"),
+    ("died in:", "place_where.transit_destinations"),
+    ("interned in:", "place_where.transit_destinations"),
+    ("imprisoned in:", "place_where.transit_destinations"),
+    ("in:", "place_where.transit_destinations"),
+]
+
+# patterns on the normalized label (hyphens are already spaces post-normalize).
+_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"^age \d{2}( \d{2}|\+| \+)?$"), "person_who.age_group"),
+    (re.compile(r"^\d{2}( \d{2})?(\+| \+)?( years)?$"), "person_who.age_group"),
+    (re.compile(r"\(tone\)$"), "language_how.tone"),
+    (re.compile(r"^barrack(s)? \d"), "place_where.camp_areas"),
+    (re.compile(r"^camp "), "place_where.transit_destinations"),
+]
+
+# category / rollup tags that match by membership, not a literal subtag. The visitor
+# side emits the matching rollup key for the complement set (e.g. any non-core
+# nationality also emits "international"). See ai_engine.recsys.survey.CORE_COUNTRIES.
+_ROLLUP: dict[str, str] = {
+    "international": "person_who.city_village_country",
+}
+
+DEFAULT_FACET = "theme_what"
+
+
+@lru_cache(maxsize=1)
+def _load_index() -> tuple[dict[str, str], dict[str, str], str]:
+    """Build (exact_label->facet, theme_subtag->main_tag, source) from tags.json."""
+    tax = json.loads(_TAGS_JSON.read_text("utf-8"))
+    exact: dict[str, str] = {}
+    sub_to_main: dict[str, str] = {}
+
+    def expand(subtag: str):
+        if "/" in subtag:
+            head, _, tail = subtag.partition(" ")
+            if "/" in head:
+                for opt in head.split("/"):
+                    yield f"{opt} {tail}".strip()
+            for opt in subtag.split("/"):
+                yield opt.strip()
+        yield subtag
+
+    for dim in tax["dimensions"]:
+        dkey = dim["key"]
+        for m in dim.get("main_tags", []):
+            main = m.get("tag")
+            if not main:
+                continue
+            exact[normalize_label(main)] = "theme_what"
+            for st in m.get("subtags", []):
+                for variant in expand(st):
+                    nv = normalize_label(variant)
+                    exact.setdefault(nv, "theme_what")
+                    sub_to_main[nv] = main
+        for g in dim.get("groups", []):
+            facet = _GROUP_FACET.get((dkey, g.get("label", "")))
+            if facet is None:
+                continue
+            if not g.get("subtags") and dkey == "theme_how":
+                exact[normalize_label(g["label"])] = facet
+            for st in g.get("subtags", []):
+                for variant in expand(st):
+                    exact.setdefault(normalize_label(variant), facet)
+        for st in dim.get("subtags", []):
+            facet = {"medium_what": "medium_what"}.get(dkey, dkey)
+            exact.setdefault(normalize_label(st), facet)
+
+    return exact, sub_to_main, str(tax.get("source", ""))
+
+
+@dataclass(frozen=True)
+class FacetAssignment:
+    facet: str
+    label: str          # canonical label written to the content tag (the GRANULAR one)
+    source: str         # pattern | prefix | exact | subtag | rollup | default
+    rollup: str | None = None  # parent main-tag label to ALSO emit, for coarse matching
+
+
+def assign_facet(tag: str) -> FacetAssignment:
+    """Classify one flat Omeka tag string into ``{facet, label, source, rollup}``.
+
+    For a theme subtag the granular label is kept as ``label`` and the parent main
+    tag is returned in ``rollup`` (emit both via :func:`to_tags`) so richness is
+    preserved while still matching the main-level theme the survey asks about."""
+    exact, sub_to_main, _ = _load_index()
+    norm = normalize_label(_decode_aiar(str(tag)))
+
+    if norm in sub_to_main:
+        main = normalize_label(sub_to_main[norm])
+        # keep the granular subtag; main is an additive rollup (unless it IS the main)
+        return FacetAssignment("theme_what", norm, "subtag", rollup=None if norm == main else main)
+    if norm in _ROLLUP:
+        return FacetAssignment(_ROLLUP[norm], norm, "rollup")
+    if norm in exact:
+        return FacetAssignment(exact[norm], norm, "exact")
+    for pat, facet in _PATTERNS:
+        if pat.search(norm):
+            return FacetAssignment(facet, norm, "pattern")
+    for prefix, facet in sorted(_PREFIXES, key=lambda p: -len(p[0])):
+        if norm.startswith(prefix):
+            return FacetAssignment(facet, norm, "prefix")
+    return FacetAssignment(DEFAULT_FACET, norm, "default")
+
+
+def to_tag(tag: str, *, weight: float = 1.0) -> dict:
+    """Flat Omeka tag string -> the single PRIMARY (granular) structured tag dict.
+    Use :func:`to_tags` to also get the main-tag rollup for theme subtags."""
+    a = assign_facet(tag)
+    return {"facet": a.facet, "label": a.label, "weight": weight}
+
+
+def to_tags(tag: str, *, weight: float = 1.0, rollup_weight: float | None = None) -> list[dict]:
+    """Flat Omeka tag string -> structured tag dict(s).
+
+    Returns the granular tag plus, for a theme subtag, an additional rollup tag for
+    its parent main theme so coarse survey answers still match without losing the
+    fine-grained label. ``rollup_weight`` defaults to ``weight``."""
+    a = assign_facet(tag)
+    out = [{"facet": a.facet, "label": a.label, "weight": weight}]
+    if a.rollup:
+        out.append({"facet": "theme_what", "label": a.rollup,
+                    "weight": weight if rollup_weight is None else rollup_weight})
+    return out
+
+
+def review_vocab(tags) -> list[FacetAssignment]:
+    """Classify an iterable of flat tag strings; for auditing the mapping."""
+    return [assign_facet(t) for t in tags]


### PR DESCRIPTION
## Problem
`0.6.2` CrashLoopBackOff in prod. `recsys/taxonomy.py` imports the `memorise_taxonomy` package at module load (the faceted-normalization / `to_tags` work), but that package is a **private, unpublished repo** and the recsys Docker build context is `ai-engine/` only — so the image **never installed it** → `ImportError` on startup.

## Fix
Vendor the pure-python, dependency-free `memorise_taxonomy` package into `src/memorise_taxonomy/`. The image already has `PYTHONPATH=/app/src` + `COPY src ./src`, so it becomes importable with **no Dockerfile / index / build-secret changes**.

- `data/tags.json` is force-added past the repo-wide `data` gitignore rule (loaded at runtime) + a `.gitignore` exception added.
- Verified `create_app()` boots with `AI_ENGINE_DEV=0` (the prod path).
- Vendored from `memorise-taxonomy@c792153`. See `src/memorise_taxonomy/VENDORED.md` for re-sync + the publish-to-index follow-up.

## Note
Prod is currently rolled back to `dabadav:0.6.1` (working). After merge: tag `v0.6.3` → CI builds `ai-engine-memorise/ai-engine-recsys:0.6.3` → re-point Flux to `ai-engine-memorise` → automation deploys `0.6.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)