### PR TITLE
feat: expose running version at /health

### DIFF
--- a/src/ai_engine/recsys/api.py
+++ b/src/ai_engine/recsys/api.py
@@ -1054,7 +1054,9 @@ def create_app(components: Optional[Components] = None) -> FastAPI:
 
     @app.get("/health", tags=["Health"])
     def health() -> dict:
-        return {"status": "ok"}
+        # APP_VERSION is set from the deployed image tag via the Flux imagepolicy
+        # setter (see deployment.yaml), so this reports the running release.
+        return {"status": "ok", "version": os.getenv("APP_VERSION", "unknown")}
 
     @app.get("/dashboard", tags=["Control panel"])
     def dashboard():


### PR DESCRIPTION
## What
`/health` now returns `{"status":"ok","version": APP_VERSION}`.

## Why
"Which version is running?" had no answer — `/health` returned only `{"status":"ok"}`. `APP_VERSION` is wired to the deployed image tag via the Flux imagepolicy setter (deployment env, separate flux MR), so it auto-bumps with each release. No manual maintenance.