### PR TITLE
perf: bound /served/recent to newest day partition

### DIFF
--- a/src/ai_engine/recsys/api.py
+++ b/src/ai_engine/recsys/api.py
@@ -157,6 +157,46 @@ def _served_record(request_id: str, user_id: str, items: list, out: dict, filter
     }
 
 
+def _tail_served(base: str, n: int) -> list[dict]:
+    """Latest n served-impression rows, newest first.
+
+    log_served writes one parquet PER request into served/date=YYYY-MM-DD/, so the
+    dataset is many tiny files. Reading them all to return a short tail is O(history).
+    Date dirs sort chronologically, so read newest-day-first and stop at the first
+    partition boundary once we have >= n rows: cost scales with the newest day(s).
+    ponytail: one row per file means a busy day is still many files — add a daily
+    parquet compaction job if a single day's read becomes the bottleneck.
+    """
+    import glob
+    import json
+    import pyarrow.parquet as pq
+
+    files = sorted(glob.glob(os.path.join(base, "served", "**", "*.parquet"), recursive=True),
+                   reverse=True)  # date=YYYY-MM-DD sorts chronologically -> newest first
+    rows: list = []
+    cur_day = None
+    for f in files:
+        day = os.path.dirname(f)
+        if len(rows) >= n and day != cur_day:
+            break  # enough rows AND the previous day partition is fully read
+        cur_day = day
+        try:
+            rows.extend(pq.read_table(f).to_pylist())
+        except Exception:
+            continue
+    rows.sort(key=lambda r: r.get("ts") or "", reverse=True)
+    out = []
+    for r in rows[:n]:
+        items = r.get("items")
+        if isinstance(items, str):
+            try:
+                items = json.loads(items)
+            except Exception:
+                items = []
+        out.append({**r, "items": items})
+    return out
+
+
 def _log_base(c) -> Optional[str]:
     """The CURRENT tenant's event-log directory (where served/ + date=*/ live).
     Per-tenant ParquetEventLog has `.base`; fall back to the global env for single-tenant."""
@@ -699,32 +739,14 @@ def make_router(components: Components) -> APIRouter:
     @ops.get("/served/recent")
     def served_recent(n: int = Query(default=50, ge=1, le=500)) -> dict:
         """Tail of the durable served-impression log (PII -> guarded). Per-tenant log dir."""
-        import glob
-        import json
         base = _log_base(c)
         if not base:
             return {"result": [], "detail": "EVENT_LOG_DIR not set"}
         try:
-            import pyarrow.parquet as pq
+            import pyarrow.parquet  # noqa: F401  (presence check; helper imports it)
         except ImportError:
             return {"result": [], "detail": "pyarrow not installed"}
-        rows: list = []
-        for f in glob.glob(os.path.join(base, "served", "**", "*.parquet"), recursive=True):
-            try:
-                rows.extend(pq.read_table(f).to_pylist())
-            except Exception:
-                continue
-        rows.sort(key=lambda r: r.get("ts") or "", reverse=True)
-        out = []
-        for r in rows[:n]:
-            items = r.get("items")
-            if isinstance(items, str):
-                try:
-                    items = json.loads(items)
-                except Exception:
-                    items = []
-            out.append({**r, "items": items})
-        return {"result": out}
+        return {"result": _tail_served(base, n)}
 
     @ops.get("/served/explain")
     def served_explain(request_id: str = Query(..., description="served impression request_id")) -> dict:

--- a/tests/test_served_recent.py
+++ b/tests/test_served_recent.py
@@ -1,0 +1,41 @@
+"""_tail_served: returns the latest n served rows newest-first, bounded to the
+newest day partition(s) instead of reading the whole history."""
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from ai_engine.recsys.api import _tail_served
+
+
+def _write(base, day, ts, rid):
+    d = base / "served" / f"date={day}"
+    d.mkdir(parents=True, exist_ok=True)
+    row = {"request_id": rid, "ts": ts, "items": json.dumps([{"id": rid}])}
+    pq.write_table(pa.Table.from_pylist([row]), d / f"part-{rid}.parquet")
+
+
+def test_tail_newest_first_and_items_parsed(tmp_path):
+    # one row per file, mirroring log_served; within-day files are NOT ts-ordered.
+    _write(tmp_path, "2026-06-21", "2026-06-21T10:00:00", "old")
+    _write(tmp_path, "2026-06-22", "2026-06-22T09:00:00", "a")
+    _write(tmp_path, "2026-06-22", "2026-06-22T11:00:00", "c")
+    _write(tmp_path, "2026-06-22", "2026-06-22T10:00:00", "b")
+
+    out = _tail_served(str(tmp_path), n=2)
+
+    # newest two, correctly ordered — catches a premature mid-day break that would
+    # miss "c" (read after "a"/"b" within the same day).
+    assert [r["request_id"] for r in out] == ["c", "b"]
+    assert out[0]["items"] == [{"id": "c"}]  # JSON-stringified items decoded
+
+
+def test_tail_crosses_day_when_needed(tmp_path):
+    _write(tmp_path, "2026-06-21", "2026-06-21T10:00:00", "old")
+    _write(tmp_path, "2026-06-22", "2026-06-22T09:00:00", "new")
+    out = _tail_served(str(tmp_path), n=5)
+    assert [r["request_id"] for r in out] == ["new", "old"]
+
+
+def test_tail_empty(tmp_path):
+    assert _tail_served(str(tmp_path), n=10) == []


### PR DESCRIPTION
## What
`/served/recent` (Traffic panel) read **every** parquet in the served log and deserialized all rows just to return the latest `n`.

## Why slow
`log_served` writes one parquet file per request → the dataset is thousands of tiny files. The endpoint was O(entire history) per dashboard load, degrading as traffic grew.

## Fix
Date dirs (`served/date=YYYY-MM-DD/`) sort chronologically. Read newest-day-first, stop at the first day boundary once `n` rows are collected. Cost scales with the newest day(s). Extracted `_tail_served()` with tests.

Known ceiling (marked `ponytail:`): one row per file means a busy single day is still many files — add daily parquet compaction if one day's read becomes the bottleneck.