### PR TITLE
feat: sortable visitor history + content-index audit

### DIFF
--- a/src/ai_engine/recsys/api.py
+++ b/src/ai_engine/recsys/api.py
@@ -523,6 +523,7 @@ def make_router(components: Components) -> APIRouter:
 
         agg_rows = [{
             "content_id": cid, "title": titles.get(cid, ""), "visits": a.visits,
+            "indexed": cid in titles,        # False -> engaged item missing from this tenant's qdrant collection
             "dwell_seconds": a.dwell_seconds,
             "end_reason": a.end_reason.value if a.end_reason else None,
             "last_ts": a.last_ts.isoformat() if a.last_ts else None,
@@ -539,6 +540,7 @@ def make_router(components: Components) -> APIRouter:
         } for e in sorted(events, key=lambda e: e.ts, reverse=True)[:limit]]
 
         return {"result": {"user_id": user_id, "event_count": len(events),
+                           "unindexed": sum(1 for r in agg_rows if not r["indexed"]),
                            "aggregates": agg_rows, "events": ev_rows}}
 
     @ops.get("/clusters")
@@ -640,6 +642,7 @@ def make_router(components: Components) -> APIRouter:
             pos = positive.get(cid, 0)
             content.append({
                 "content_id": cid, "title": titles.get(cid, ""),
+                "indexed": cid in titles,                            # resolvable in this tenant's qdrant collection
                 "views": v_,                                          # times viewed (events)
                 "users": users_n,                                    # unique users exposed
                 "avg_dwell": round(dwell.get(cid, 0.0) / v_, 1) if v_ else 0.0,
@@ -647,6 +650,17 @@ def make_router(components: Components) -> APIRouter:
                 "positive_rate": round(pos / users_n, 3) if users_n else 0.0,   # positive vs others
             })
         content.sort(key=lambda r: (r["views"], r["users"]), reverse=True)
+
+        # Index audit (Phase 1): engaged content the app served but which is absent from
+        # this tenant's qdrant collection (filtered at ingest, deleted, or post-snapshot).
+        # Such items show as a bare id with no title/tags anywhere downstream.
+        missing = [cid for cid in all_cids if cid not in titles]
+        missing.sort(key=lambda cid: visits.get(cid, 0), reverse=True)
+        audit = {
+            "seen_total": len(all_cids),
+            "unindexed": len(missing),
+            "unindexed_ids": missing[:500],          # bounded; full count is in `unindexed`
+        }
 
         themes = sorted(([lbl(k), round(w, 3)] for k, w in theme.items()),
                         key=lambda kv: kv[1], reverse=True)[:15]
@@ -675,7 +689,7 @@ def make_router(components: Components) -> APIRouter:
                 })
 
         return {"result": {"users": len(sigs), "content": content[:limit],
-                           "themes": themes, "clusters": clusters}}
+                           "audit": audit, "themes": themes, "clusters": clusters}}
 
     @ops.get("/content/{content_id}")
     def content_detail(content_id: str) -> dict:

--- a/src/ai_engine/recsys/static/dashboard.html
+++ b/src/ai_engine/recsys/static/dashboard.html
@@ -386,7 +386,12 @@ const COLORS={semantic:"var(--c-semantic)",affinity:"var(--c-affinity)",tag:"var
 const $=(s,el=document)=>el.querySelector(s);
 const el=(t,a={},...kids)=>{const e=document.createElement(t);for(const k in a){if(k==="class")e.className=a[k];else if(k==="html")e.innerHTML=a[k];else if(k.startsWith("on"))e[k]=a[k];else e.setAttribute(k,a[k]);}for(const k of kids.flat())e.append(k&&k.nodeType?k:document.createTextNode(k??""));return e;};
 const base=()=>window.location.origin;   // dashboard is served by the API itself, so same-origin
-const headers=()=>{const h={};const k=$("#key").value.trim();if(k)h["X-API-Key"]=k;const t=$("#tenant").value.trim();if(t)h["X-Tenant-Id"]=t;return h;};
+// scope of the active X-API-Key, set by loadWhoami(): "tenant" (per-tenant key, tenant is
+// key-derived) | "global" (superuser, may target a tenant) | "public" | null (unknown yet).
+let keyScope=null;
+// X-Tenant-Id only matters for the global/public path; a per-tenant key is authoritative and
+// the server ignores the header — omit it so a stale value can't leak if the key later changes.
+const headers=()=>{const h={};const k=$("#key").value.trim();if(k)h["X-API-Key"]=k;const t=$("#tenant").value.trim();if(t&&keyScope!=="tenant")h["X-Tenant-Id"]=t;return h;};
 async function api(path){const r=await fetch(base()+path,{headers:headers()});if(!r.ok)throw new Error(r.status+" "+r.statusText+", "+path);return (await r.json()).result;}
 const fmt=x=>(typeof x==="number")?(Math.round(x*1000)/1000):x;
 const mdInline=t=>String(t??"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/\*\*(.+?)\*\*/g,"<strong>$1</strong>");
@@ -1502,10 +1507,14 @@ async function ping(){try{const r=await fetch(base()+"/health");setConn(r.ok);if
 // Tenant is key-derived (never spoofable). Show the resolved name + scope in the sidebar.
 async function loadWhoami(){
   try{const w=await api("/api/whoami");
+    keyScope=w.scope||null;
     $("#tenantname").textContent=w.tenant||"default";
     const sc=w.scope==="global"?"global key":w.scope==="tenant"?"tenant key":"public";
     $("#conn").title="connected · "+sc;
-  }catch(e){$("#tenantname").textContent=($("#tenant").value.trim()||"default");}
+    // per-tenant key pins the tenant -> a leftover X-Tenant-Id is dead weight; drop it so it
+    // can't silently retarget a later global-key session.
+    if(w.scope==="tenant"&&$("#tenant").value){$("#tenant").value="";localStorage.removeItem("ins_tenant");}
+  }catch(e){keyScope=null;$("#tenantname").textContent=($("#tenant").value.trim()||"default");}
 }
 
 /* ===== routing & boot ===== */

--- a/src/ai_engine/recsys/static/dashboard.html
+++ b/src/ai_engine/recsys/static/dashboard.html
@@ -210,6 +210,9 @@ main{flex:1 1 auto;min-width:0}
 table{width:100%;border-collapse:collapse;font-size:13px}
 th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:middle}
 th{color:var(--mut);font-weight:700;font-size:10px;text-transform:uppercase;letter-spacing:.06em}
+th.th-sort{cursor:pointer;user-select:none;white-space:nowrap}
+th.th-sort:hover{color:var(--fg)}
+th.th-sort .sortind{font-size:9px;color:var(--accent);letter-spacing:0}
 tbody tr{transition:background .12s}
 tbody tr:hover{background:var(--accent-t)}
 td:first-child,th:first-child{padding-left:2px} td:last-child,th:last-child{padding-right:2px}
@@ -743,11 +746,26 @@ async function renderContent(v){
   let r;try{r=await api("/api/content/stats");}catch(e){failCard(v,e);return;}
   if(!r||!r.users){v.append(el("div",{class:"empty"},"No visitor data yet. Ingest some events first."));return;}
   v.append(el("div",{class:"row small mut",style:"margin-bottom:12px"},`${r.users} visitors / ${r.content.length} content items seen`));
+  const au=r.audit;
+  if(au&&au.unindexed){
+    const card=el("div",{class:"card"},
+      el("div",{class:"row",style:"gap:9px;align-items:center"},
+        el("span",{class:"pill distractor"},"index audit"),
+        el("b",{},`${au.unindexed} of ${au.seen_total} engaged items not in the content index`)),
+      el("div",{class:"small mut",style:"margin-top:6px"},"Items visitors engaged with that are absent from this tenant's qdrant collection — they render as a bare id with no title or tags. Cause: filtered at ingest (<5 words & no image, or test-collection id), deleted, or created after the last content sync."));
+    if(au.unindexed_ids&&au.unindexed_ids.length){
+      const ids=el("div",{class:"row small num",style:"gap:6px;flex-wrap:wrap;margin-top:9px"});
+      au.unindexed_ids.forEach(cid=>ids.append(el("span",{class:"pill neutral",style:"cursor:pointer",title:"open content card",onclick:()=>openContentDetail(cid)},cid)));
+      card.append(ids);
+      if(au.unindexed>au.unindexed_ids.length)card.append(el("div",{class:"small mut",style:"margin-top:6px"},`+${au.unindexed-au.unindexed_ids.length} more`));
+    }
+    v.append(card);
+  }
   const tbl=el("table");
   tbl.append(el("tr",{},el("th",{},"content"),el("th",{class:"num"},"views"),el("th",{class:"num"},"users"),
     el("th",{class:"num"},"avg dwell"),el("th",{style:"width:180px"},"positive rate")));
   for(const x of r.content)tbl.append(el("tr",{style:"cursor:pointer",title:"open content card",onclick:()=>openContentDetail(x.content_id)},
-    el("td",{},el("div",{},x.title||x.content_id),x.title?el("div",{class:"small mut num"},x.content_id):""),
+    el("td",{},el("div",{},x.title||x.content_id,x.indexed?"":el("span",{class:"pill distractor",style:"margin-left:7px;font-size:9px",title:"not in this tenant's qdrant collection"},"not indexed")),x.title?el("div",{class:"small mut num"},x.content_id):""),
     el("td",{class:"num"},x.views),
     el("td",{class:"num"},x.users),
     el("td",{class:"num small mut"},x.avg_dwell?x.avg_dwell+"s":"—"),
@@ -905,27 +923,61 @@ async function renderUser(v){
   v.append(el("div",{class:"pgrid"},left,right));
 }
 
+// Sortable table. cols: [{label, cell(row)->td, sort?(row)->comparable, num?, thClass?}].
+// A column with no `sort` is static. Click a header to sort by it (re-click toggles
+// asc/desc); shift-click adds it as an additional (lower-priority) key for multi-column
+// sort. `init` = optional starting [{i,dir}] sort state. Nulls always sort last.
+function sortableTable(cols,rows,init){
+  const tbl=el("table"); let sorts=(init||[]).slice();
+  const head=el("tr");
+  cols.forEach((col,i)=>{
+    if(!col.sort){head.append(el("th",{class:col.thClass||""},col.label));return;}
+    const ind=el("span",{class:"sortind"},"");
+    const th=el("th",{class:"th-sort "+(col.thClass||""),title:"click to sort · shift-click to add a column"},col.label," ",ind);
+    th.onclick=(ev)=>{const ex=sorts.find(s=>s.i===i);
+      if(ev.shiftKey){ if(ex) ex.dir=-ex.dir; else sorts.push({i,dir:1}); }
+      else { if(sorts.length===1&&ex) ex.dir=-ex.dir; else sorts=[{i,dir:ex?ex.dir:1}]; }
+      draw();};
+    col._ind=ind; head.append(th);
+  });
+  tbl.append(head); let body=el("tbody"); tbl.append(body);
+  const cmp=(a,b)=>{for(const s of sorts){const c=cols[s.i];let av=c.sort(a),bv=c.sort(b);
+    if(av==null&&bv==null)continue; if(av==null)return 1; if(bv==null)return -1;
+    const r=c.num?(av-bv):String(av).localeCompare(String(bv)); if(r)return r*s.dir;} return 0;};
+  function draw(){
+    cols.forEach((c,i)=>{if(!c._ind)return;const k=sorts.findIndex(s=>s.i===i);const s=sorts[k];
+      c._ind.textContent=s?((s.dir>0?"▲":"▼")+(sorts.length>1?(k+1):"")):"";});
+    const ordered=sorts.length?rows.slice().sort(cmp):rows;
+    const nb=el("tbody"); for(const row of ordered)nb.append(el("tr",{},...cols.map(c=>c.cell(row))));
+    body.replaceWith(nb); body=nb;
+  }
+  draw(); return tbl;
+}
 async function renderHistory(v){
   let h;try{h=await api(`/api/usermodel/history?user_id=${encodeURIComponent($("#uid").value)}`);}catch(e){failCard(v,e);return;}
   if(!h||!h.event_count){v.append(el("div",{class:"empty"},"No activity for ",el("b",{},$("#uid").value),". Ingest events for this user first."));return;}
-  v.append(el("div",{class:"row small mut",style:"margin-bottom:12px"},`${h.event_count} events / ${h.aggregates.length} content items engaged`));
+  v.append(el("div",{class:"row small mut",style:"margin-bottom:12px"},`${h.event_count} events / ${h.aggregates.length} content items engaged · click a column to sort, shift-click to sort by several`));
+  if(h.unindexed)v.append(el("div",{class:"row small",style:"margin:-4px 0 12px;color:var(--warn,#c98a00)"},
+    el("span",{class:"pill distractor",style:"margin-right:7px"},"not indexed"),
+    `${h.unindexed} engaged item${h.unindexed>1?"s":""} missing from this tenant's content index — shown as a bare id, no title/tags. Likely filtered at ingest or not yet synced.`));
   const dwell=d=>d!=null?Math.round(d)+"s":"-";
-  const at=el("table");
-  at.append(el("tr",{},el("th",{},"content"),el("th",{},"visits"),el("th",{},"dwell"),el("th",{},"end reason"),el("th",{},"outcome")));
-  for(const a of h.aggregates){const oc=a.outcome==="positive"?"warm":a.outcome==="negative"?"distractor":"neutral";
-    at.append(el("tr",{},
-      el("td",{},el("div",{},a.title||a.content_id),a.title?el("div",{class:"small mut num"},a.content_id):""),
-      el("td",{class:"num"},a.visits),el("td",{class:"num"},dwell(a.dwell_seconds)),
-      el("td",{class:"small mut"},a.end_reason||"-"),el("td",{},el("span",{class:"pill "+oc},a.outcome))));}
+  const ocClass=o=>o==="positive"?"warm":o==="negative"?"distractor":"neutral";
+  const at=sortableTable([
+    {label:"content",sort:a=>(a.title||a.content_id||"").toLowerCase(),
+     cell:a=>el("td",{},el("div",{},a.title||a.content_id,a.indexed?"":el("span",{class:"pill distractor",style:"margin-left:7px;font-size:9px",title:"not in this tenant's qdrant collection"},"not indexed")),a.title?el("div",{class:"small mut num"},a.content_id):"")},
+    {label:"visits",num:true,thClass:"num",sort:a=>a.visits,cell:a=>el("td",{class:"num"},a.visits)},
+    {label:"dwell",num:true,thClass:"num",sort:a=>a.dwell_seconds,cell:a=>el("td",{class:"num"},dwell(a.dwell_seconds))},
+    {label:"end reason",sort:a=>a.end_reason||"",cell:a=>el("td",{class:"small mut"},a.end_reason||"-")},
+    {label:"outcome",sort:a=>a.outcome||"",cell:a=>el("td",{},el("span",{class:"pill "+ocClass(a.outcome)},a.outcome))},
+  ],h.aggregates);
   v.append(el("div",{class:"card"},cardhead("Engaged content"),at));
-  const et=el("table");
-  et.append(el("tr",{},el("th",{},"time"),el("th",{},"event"),el("th",{},"content"),el("th",{},"dwell"),el("th",{},"reason")));
-  for(const e of h.events)et.append(el("tr",{},
-    el("td",{class:"small mut num"},(e.ts||"").replace("T"," ").slice(0,19)),
-    el("td",{class:"small"},(e.event||"").replace("CONTENT_","").replace(/_/g," ").toLowerCase()),
-    el("td",{class:"small"},e.title||e.content_id||"-"),
-    el("td",{class:"num small"},e.dwell_seconds!=null?Math.round(e.dwell_seconds)+"s":""),
-    el("td",{class:"small mut"},e.end_reason||"")));
+  const et=sortableTable([
+    {label:"time",num:true,thClass:"num",sort:e=>e.ts||"",cell:e=>el("td",{class:"small mut num"},(e.ts||"").replace("T"," ").slice(0,19))},
+    {label:"event",sort:e=>e.event||"",cell:e=>el("td",{class:"small"},(e.event||"").replace("CONTENT_","").replace(/_/g," ").toLowerCase())},
+    {label:"content",sort:e=>(e.title||e.content_id||"").toLowerCase(),cell:e=>el("td",{class:"small"},e.title||e.content_id||"-")},
+    {label:"dwell",num:true,thClass:"num",sort:e=>e.dwell_seconds,cell:e=>el("td",{class:"num small"},e.dwell_seconds!=null?Math.round(e.dwell_seconds)+"s":"")},
+    {label:"reason",sort:e=>e.end_reason||"",cell:e=>el("td",{class:"small mut"},e.end_reason||"")},
+  ],h.events,[{i:0,dir:-1}]);
   v.append(el("div",{class:"card"},cardhead("Event timeline"),et));
 }
 


### PR DESCRIPTION
## Sortable history columns
Both visitor-history tables (Engaged content, Event timeline) are now sortable:
- **Click** a column header to sort (re-click toggles asc/desc).
- **Shift-click** to add columns for multi-key sort; indicators show `▲/▼` + priority number.
- Reusable `sortableTable()` helper. Numeric columns sort numerically, nulls last, timeline defaults to newest-first.

## Content-index audit (Phase 1, read-only)
Surfaces engaged content the app served but which is **absent from the tenant's qdrant collection** — items that otherwise render as a bare id with no title/tags (e.g. dropped at ingest by the `<5 words & no image` / test-collection filters, deleted, or created after the last content snapshot).

- `GET /api/content/stats` → new `audit` block (`seen_total` / `unindexed` / `unindexed_ids`) + per-item `indexed`.
- `GET /api/usermodel/history` → per-aggregate `indexed` + top-level `unindexed`.
- Dashboard: Content view audit card + "not indexed" badges; visitor History banner + row badges.

Reuses the existing `content_store.get` title resolution, so no extra qdrant traffic and no new parquet scan. **Read-only** — the scheduled-delta sync/heal worker is a later phase.

## Verify
`node --check` on the extracted dashboard JS and `py_compile` on `api.py` both pass. The running dev server (:8001) needs a restart to serve the new fields.