### PR TITLE
fix(recsys): demographic province seeds the correct person_who facet

### DIFF
--- a/src/ai_engine/recsys/signals/signal_builder.py
+++ b/src/ai_engine/recsys/signals/signal_builder.py
@@ -253,8 +253,8 @@ def _demographic_affinity(demographics: dict) -> dict[str, float]:
     if nat:
         out[f"person_who.city_village_country:From: {str(nat).capitalize()}"] = 0.4
     prov = demographics.get("province")
-    if prov:   # matches the content's place_where.province_netherlands:<Province> tags
-        out[f"place_where.province_netherlands:{str(prov).strip()}"] = 0.5
+    if prov:   # matches the content's person_who.province_netherlands:<Province> tags
+        out[f"person_who.province_netherlands:{str(prov).strip()}"] = 0.5
     return out
 
 

--- a/tests/test_survey.py
+++ b/tests/test_survey.py
@@ -89,11 +89,12 @@ def test_survey_event_seeds_user_model():
     assert sig.demographics.get("age") == "25_34"  # stored -> retrievable via /usermodel
 
 
-def test_province_maps_to_place_where_facet():
+def test_province_maps_to_person_who_facet():
+    # province tags live under person_who.province_netherlands (tags.json / live Qdrant)
     a = survey_affinity({"q:province": "Utrecht"})
-    assert a["place_where.province_netherlands:Utrecht"] == 0.5
+    assert a["person_who.province_netherlands:Utrecht"] == 0.5
     b = survey_affinity({"province": "Zuid-Holland"})            # hyphen preserved (matters)
-    assert "place_where.province_netherlands:Zuid-Holland" in b
+    assert "person_who.province_netherlands:Zuid-Holland" in b
     assert extract_demographics({"q:province": "Gelderland"})["province"] == "Gelderland"
 
 
@@ -102,7 +103,7 @@ def test_province_seeds_affinity_matching_content_tags():
     ev = InteractionEvent(user_id="u", event="SURVEY_SUBMITTED", ts=NOW,
                           survey_answers={"q:province": "Utrecht"})
     sig = build_user_signals(user_id="u", events=[ev], contents={}, vectors={}, now=NOW, cfg=CFG)
-    assert "place_where.province_netherlands:utrecht" in sig.tag_affinity   # lowercased fold
+    assert "person_who.province_netherlands:utrecht" in sig.tag_affinity   # lowercased fold
 
 
 def test_identify_payload_normalizes_to_demographic_event():


### PR DESCRIPTION
## Problem
`_demographic_affinity` wrote `place_where.province_netherlands`, but content province tags live under `person_who.province_netherlands`. Confirmed three ways:
- taxonomy authority: `tags.json` places the "Province (Netherlands)" group under the `person_who` dimension (`taxonomy.py` `_GROUP_FACET`).
- live Qdrant (`westerbork-ar-ai`): province tags are `person_who.province_netherlands:<province>` (e.g. `zuid holland`); zero `place_where.province_netherlands`.
- normalization test: the survey key matches content, the `place_where` key does not.

So a province seeded via the demographics provider matched no content (dead seed).

## Fix
- `signal_builder.py`: write `person_who.province_netherlands`, aligning with `survey_affinity` (already correct).
- `test_survey.py`: correct two stale tests that asserted the `place_where` facet, contradicting `test_taxonomy.py` and the live data.

Full suite green except one unrelated pre-existing failure (`test_settings_page_served`).